### PR TITLE
Bug fix

### DIFF
--- a/command/convert.go
+++ b/command/convert.go
@@ -50,10 +50,10 @@ func convertExec(filePath string) {
 	fileConverter := converter.NewFile(uploadSideFile)
 	textConverter := converter.NewText(uploadSideFile)
 	for testKey, test := range uploadSideFile.Tests {
-		for commandKey, command := range test.Commands {
-			xpathConverter.Exec(testKey, commandKey, command)
-			fileConverter.Exec(testKey, commandKey, command)
-			textConverter.Exec(testKey, commandKey, command)
+		for commandKey := range test.Commands {
+			xpathConverter.Exec(testKey, commandKey)
+			fileConverter.Exec(testKey, commandKey)
+			textConverter.Exec(testKey, commandKey)
 		}
 	}
 	xpathConverter.After()

--- a/converter/file.go
+++ b/converter/file.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/gtongy/sideconv/selenium"
 	"github.com/gtongy/sideconv/setting"
@@ -36,8 +37,8 @@ func NewFile(uploadSideFile *selenium.SideFile) File {
 func (f *File) Exec(testKey int, commandKey int) {
 	command := &f.uploadSideFile.Tests[testKey].Commands[commandKey]
 
-	if value := f.fileSetting.GetByTemplate(command.Value); value != "" {
-		command.Value = filepath.Join(f.fileSetting.BaseURL, value)
+	for template, file := range f.fileSetting.GetTemplates(command.Value) {
+		command.Value = strings.Replace(command.Value, template, filepath.Join(f.fileSetting.BaseURL, file), -1)
 	}
 }
 

--- a/converter/file.go
+++ b/converter/file.go
@@ -33,11 +33,14 @@ func NewFile(uploadSideFile *selenium.SideFile) File {
 }
 
 // Exec 処理の実行
-func (f *File) Exec(testKey int, commandKey int, command selenium.Command) {
-	fileKey := command.GetValueFileKey(f.fileSetting.Files)
+func (f *File) Exec(testKey int, commandKey int) {
+	fileKey := f.uploadSideFile.Tests[testKey].Commands[commandKey].GetValueFileKey(f.fileSetting.Files)
 	if fileKey != "" {
 		f.uploadSideFile.Tests[testKey].Commands[commandKey].Value =
-			strings.Replace(command.Value, f.fileSetting.GetTemplate(fileKey), f.fileSetting.BaseURL+"/"+f.fileSetting.Files[fileKey], -1)
+			strings.Replace(
+				f.uploadSideFile.Tests[testKey].Commands[commandKey].Value,
+				f.fileSetting.GetTemplate(fileKey),
+				f.fileSetting.BaseURL+"/"+f.fileSetting.Files[fileKey], -1)
 	}
 }
 

--- a/converter/file.go
+++ b/converter/file.go
@@ -2,7 +2,7 @@ package converter
 
 import (
 	"io/ioutil"
-	"strings"
+	"path/filepath"
 
 	"github.com/gtongy/sideconv/selenium"
 	"github.com/gtongy/sideconv/setting"
@@ -34,13 +34,10 @@ func NewFile(uploadSideFile *selenium.SideFile) File {
 
 // Exec 処理の実行
 func (f *File) Exec(testKey int, commandKey int) {
-	fileKey := f.uploadSideFile.Tests[testKey].Commands[commandKey].GetValueFileKey(f.fileSetting.Files)
-	if fileKey != "" {
-		f.uploadSideFile.Tests[testKey].Commands[commandKey].Value =
-			strings.Replace(
-				f.uploadSideFile.Tests[testKey].Commands[commandKey].Value,
-				f.fileSetting.GetTemplate(fileKey),
-				f.fileSetting.BaseURL+"/"+f.fileSetting.Files[fileKey], -1)
+	command := &f.uploadSideFile.Tests[testKey].Commands[commandKey]
+
+	if value := f.fileSetting.GetByTemplate(command.Value); value != "" {
+		command.Value = filepath.Join(f.fileSetting.BaseURL, value)
 	}
 }
 

--- a/converter/text.go
+++ b/converter/text.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"io/ioutil"
+	"strings"
 
 	"github.com/gtongy/sideconv/selenium"
 	"github.com/gtongy/sideconv/setting"
@@ -33,11 +34,12 @@ func NewText(uploadSideFile *selenium.SideFile) Text {
 func (t *Text) Exec(testKey int, commandKey int) {
 	command := &t.uploadSideFile.Tests[testKey].Commands[commandKey]
 
-	if value := t.textSetting.GetByTemplate(command.Value); value != "" {
-		command.Value = value
+	for template, text := range t.textSetting.GetTemplates(command.Value) {
+		command.Value = strings.Replace(command.Value, template, text, -1)
 	}
-	if target := t.textSetting.GetByTemplate(command.Target); target != "" {
-		command.Target = target
+
+	for template, text := range t.textSetting.GetTemplates(command.Target) {
+		command.Target = strings.Replace(command.Target, template, text, -1)
 	}
 }
 

--- a/converter/text.go
+++ b/converter/text.go
@@ -31,16 +31,22 @@ func NewText(uploadSideFile *selenium.SideFile) Text {
 }
 
 // Exec 処理の実行
-func (t *Text) Exec(testKey int, commandKey int, command selenium.Command) {
-	textValueKey := command.GetValueFileKey(t.textSetting.Texts)
+func (t *Text) Exec(testKey int, commandKey int) {
+	textValueKey := t.uploadSideFile.Tests[testKey].Commands[commandKey].GetValueTextKey(t.textSetting.Texts)
 	if textValueKey != "" {
 		t.uploadSideFile.Tests[testKey].Commands[commandKey].Value =
-			strings.Replace(command.Value, t.textSetting.GetTemplate(textValueKey), t.textSetting.Texts[textValueKey], -1)
+			strings.Replace(
+				t.uploadSideFile.Tests[testKey].Commands[commandKey].Value,
+				t.textSetting.GetTemplate(textValueKey),
+				t.textSetting.Texts[textValueKey], -1)
 	}
-	textTargetKey := command.GetTargetTextKey(t.textSetting.Texts)
+	textTargetKey := t.uploadSideFile.Tests[testKey].Commands[commandKey].GetTargetTextKey(t.textSetting.Texts)
 	if textTargetKey != "" {
 		t.uploadSideFile.Tests[testKey].Commands[commandKey].Target =
-			strings.Replace(command.Target, t.textSetting.GetTemplate(textTargetKey), t.textSetting.Texts[textTargetKey], -1)
+			strings.Replace(
+				t.uploadSideFile.Tests[testKey].Commands[commandKey].Target,
+				t.textSetting.GetTemplate(textTargetKey),
+				t.textSetting.Texts[textTargetKey], -1)
 	}
 }
 

--- a/converter/text.go
+++ b/converter/text.go
@@ -2,7 +2,6 @@ package converter
 
 import (
 	"io/ioutil"
-	"strings"
 
 	"github.com/gtongy/sideconv/selenium"
 	"github.com/gtongy/sideconv/setting"
@@ -32,21 +31,13 @@ func NewText(uploadSideFile *selenium.SideFile) Text {
 
 // Exec 処理の実行
 func (t *Text) Exec(testKey int, commandKey int) {
-	textValueKey := t.uploadSideFile.Tests[testKey].Commands[commandKey].GetValueTextKey(t.textSetting.Texts)
-	if textValueKey != "" {
-		t.uploadSideFile.Tests[testKey].Commands[commandKey].Value =
-			strings.Replace(
-				t.uploadSideFile.Tests[testKey].Commands[commandKey].Value,
-				t.textSetting.GetTemplate(textValueKey),
-				t.textSetting.Texts[textValueKey], -1)
+	command := &t.uploadSideFile.Tests[testKey].Commands[commandKey]
+
+	if value := t.textSetting.GetByTemplate(command.Value); value != "" {
+		command.Value = value
 	}
-	textTargetKey := t.uploadSideFile.Tests[testKey].Commands[commandKey].GetTargetTextKey(t.textSetting.Texts)
-	if textTargetKey != "" {
-		t.uploadSideFile.Tests[testKey].Commands[commandKey].Target =
-			strings.Replace(
-				t.uploadSideFile.Tests[testKey].Commands[commandKey].Target,
-				t.textSetting.GetTemplate(textTargetKey),
-				t.textSetting.Texts[textTargetKey], -1)
+	if target := t.textSetting.GetByTemplate(command.Target); target != "" {
+		command.Target = target
 	}
 }
 

--- a/converter/xpath.go
+++ b/converter/xpath.go
@@ -1,6 +1,7 @@
 package converter
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -35,7 +36,7 @@ func (xp *Xpath) Exec(testKey int, commandKey int) {
 	command := &xp.uploadSideFile.Tests[testKey].Commands[commandKey]
 
 	for template, xpath := range xp.xpathSetting.GetTemplates(command.Target) {
-		command.Target = strings.Replace(command.Target, template, xpath, 1)
+		command.Target = strings.Replace(command.Target, template, fmt.Sprintf("xpath=%s", xpath), 1)
 	}
 	if _, ok := xp.xpathSetting.Xpaths[command.ID]; ok {
 		return

--- a/converter/xpath.go
+++ b/converter/xpath.go
@@ -1,8 +1,8 @@
 package converter
 
 import (
-	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/gtongy/sideconv/selenium"
 	"github.com/gtongy/sideconv/setting"
@@ -34,8 +34,8 @@ func NewXpath(uploadSideFile *selenium.SideFile) Xpath {
 func (xp *Xpath) Exec(testKey int, commandKey int) {
 	command := &xp.uploadSideFile.Tests[testKey].Commands[commandKey]
 
-	if xpath := xp.xpathSetting.GetByTemplate(command.Target); xpath != "" {
-		command.Target = fmt.Sprintf("xpath=%s", xpath)
+	for template, xpath := range xp.xpathSetting.GetTemplates(command.Target) {
+		command.Target = strings.Replace(command.Target, template, xpath, 1)
 	}
 	if _, ok := xp.xpathSetting.Xpaths[command.ID]; ok {
 		return

--- a/converter/xpath.go
+++ b/converter/xpath.go
@@ -31,20 +31,23 @@ func NewXpath(uploadSideFile *selenium.SideFile) Xpath {
 }
 
 // Exec 処理の実行
-func (xp *Xpath) Exec(testKey int, commandKey int, command selenium.Command) {
-	xpathKey := command.GetTargetXpathKey(xp.xpathSetting.Xpaths)
+func (xp *Xpath) Exec(testKey int, commandKey int) {
+	xpathKey := xp.uploadSideFile.Tests[testKey].Commands[commandKey].GetTargetXpathKey(xp.xpathSetting.Xpaths)
 	if xpathKey != "" {
 		xp.uploadSideFile.Tests[testKey].Commands[commandKey].Target =
-			strings.Replace(command.Target, xp.xpathSetting.GetTemplate(xpathKey), xp.xpathSetting.Xpaths[xpathKey], -1)
+			strings.Replace(
+				xp.uploadSideFile.Tests[testKey].Commands[commandKey].Target,
+				xp.xpathSetting.GetTemplate(xpathKey),
+				xp.xpathSetting.Xpaths[xpathKey], -1)
 	}
-	if _, ok := xp.xpathSetting.Xpaths[command.ID]; ok {
+	if _, ok := xp.xpathSetting.Xpaths[xp.uploadSideFile.Tests[testKey].Commands[commandKey].ID]; ok {
 		return
 	}
-	idRelative := command.GetIDRelative()
+	idRelative := xp.uploadSideFile.Tests[testKey].Commands[commandKey].GetIDRelative()
 	if idRelative == "" || xp.xpathSetting.IsAlreadyExists(idRelative) {
 		return
 	}
-	xp.xpathSetting.Xpaths[command.ID] = idRelative
+	xp.xpathSetting.Xpaths[xp.uploadSideFile.Tests[testKey].Commands[commandKey].ID] = idRelative
 }
 
 // After 実行後処理の記述

--- a/converter/xpath.go
+++ b/converter/xpath.go
@@ -41,11 +41,6 @@ func (xp *Xpath) Exec(testKey int, commandKey int) {
 	if _, ok := xp.xpathSetting.Xpaths[command.ID]; ok {
 		return
 	}
-	idRelative := command.GetIDRelative()
-	if idRelative == "" || xp.xpathSetting.IsAlreadyExists(idRelative) {
-		return
-	}
-	xp.xpathSetting.Xpaths[command.ID] = idRelative
 }
 
 // After 実行後処理の記述

--- a/converter/xpath.go
+++ b/converter/xpath.go
@@ -1,8 +1,8 @@
 package converter
 
 import (
+	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"github.com/gtongy/sideconv/selenium"
 	"github.com/gtongy/sideconv/setting"
@@ -32,22 +32,19 @@ func NewXpath(uploadSideFile *selenium.SideFile) Xpath {
 
 // Exec 処理の実行
 func (xp *Xpath) Exec(testKey int, commandKey int) {
-	xpathKey := xp.uploadSideFile.Tests[testKey].Commands[commandKey].GetTargetXpathKey(xp.xpathSetting.Xpaths)
-	if xpathKey != "" {
-		xp.uploadSideFile.Tests[testKey].Commands[commandKey].Target =
-			strings.Replace(
-				xp.uploadSideFile.Tests[testKey].Commands[commandKey].Target,
-				xp.xpathSetting.GetTemplate(xpathKey),
-				xp.xpathSetting.Xpaths[xpathKey], -1)
+	command := &xp.uploadSideFile.Tests[testKey].Commands[commandKey]
+
+	if xpath := xp.xpathSetting.GetByTemplate(command.Target); xpath != "" {
+		command.Target = fmt.Sprintf("xpath=%s", xpath)
 	}
-	if _, ok := xp.xpathSetting.Xpaths[xp.uploadSideFile.Tests[testKey].Commands[commandKey].ID]; ok {
+	if _, ok := xp.xpathSetting.Xpaths[command.ID]; ok {
 		return
 	}
-	idRelative := xp.uploadSideFile.Tests[testKey].Commands[commandKey].GetIDRelative()
+	idRelative := command.GetIDRelative()
 	if idRelative == "" || xp.xpathSetting.IsAlreadyExists(idRelative) {
 		return
 	}
-	xp.xpathSetting.Xpaths[xp.uploadSideFile.Tests[testKey].Commands[commandKey].ID] = idRelative
+	xp.xpathSetting.Xpaths[command.ID] = idRelative
 }
 
 // After 実行後処理の記述

--- a/selenium/sideFile.go
+++ b/selenium/sideFile.go
@@ -1,9 +1,5 @@
 package selenium
 
-import (
-	"strings"
-)
-
 // SideFile .sideファイルの構造体
 type SideFile struct {
 	ID      string `json:"id"`
@@ -46,46 +42,6 @@ func (c *Command) GetIDRelative() string {
 	for _, target := range c.Targets {
 		if target[1] == "xpath:idRelative" {
 			return target[0]
-		}
-	}
-	return ""
-}
-
-// GetTargetXpathKey Target内からXpathの設定のkey名を取得
-func (c *Command) GetTargetXpathKey(xpaths map[string]string) string {
-	for key := range xpaths {
-		if strings.Index(c.Target, key) != -1 {
-			return key
-		}
-	}
-	return ""
-}
-
-// GetValueFileKey Value内からfileの設定のkey名を取得
-func (c *Command) GetValueFileKey(files map[string]string) string {
-	for key := range files {
-		if strings.Index(c.Value, key) != -1 {
-			return key
-		}
-	}
-	return ""
-}
-
-// GetTargetTextKey Target内からfileの設定のkey名を取得
-func (c *Command) GetTargetTextKey(texts map[string]string) string {
-	for key := range texts {
-		if strings.Index(c.Target, key) != -1 {
-			return key
-		}
-	}
-	return ""
-}
-
-// GetValueTextKey Value内からfileの設定のkey名を取得
-func (c *Command) GetValueTextKey(texts map[string]string) string {
-	for key := range texts {
-		if strings.Index(c.Value, key) != -1 {
-			return key
 		}
 	}
 	return ""

--- a/setting/file.go
+++ b/setting/file.go
@@ -21,16 +21,16 @@ func NewFileSetting() FileSetting {
 	}
 }
 
-// GetTemplate 変換を行う定義のテンプレートの値を取得
+// getTemplate 変換を行う定義のテンプレートの値を取得
 // ファイルの場合は {file:VAR_NAME} の形式で入力されたものに対して変換を実行
-func (fs *FileSetting) GetTemplate(key string) string {
+func (fs *FileSetting) getTemplate(key string) string {
 	return "{file:" + key + "}"
 }
 
-// GetByTemplate テンプレート形式の入力からxpathを取得する
+// GetByTemplate テンプレート形式の入力からfileを取得する
 func (fs *FileSetting) GetByTemplate(template string) string {
 	for key := range fs.Files {
-		if t := fs.GetTemplate(key); t == template {
+		if t := fs.getTemplate(key); t == template {
 			return fs.Files[key]
 		}
 	}

--- a/setting/file.go
+++ b/setting/file.go
@@ -1,6 +1,9 @@
 package setting
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 const (
 	filesDirPath = "/files"
@@ -27,13 +30,16 @@ func (fs *FileSetting) getTemplate(key string) string {
 	return "{file:" + key + "}"
 }
 
-// GetByTemplate テンプレート形式の入力からfileを取得する
-func (fs *FileSetting) GetByTemplate(template string) string {
+// GetTemplates テンプレート形式が含まれた入力からfileを取得する
+func (fs *FileSetting) GetTemplates(s string) map[string]string {
+	templates := make(map[string]string)
+
 	for key := range fs.Files {
-		if t := fs.getTemplate(key); t == template {
-			return fs.Files[key]
+		template := fs.getTemplate(key)
+		if strings.Contains(s, template) {
+			templates[template] = fs.Files[key]
 		}
 	}
 
-	return ""
+	return templates
 }

--- a/setting/file.go
+++ b/setting/file.go
@@ -26,3 +26,14 @@ func NewFileSetting() FileSetting {
 func (fs *FileSetting) GetTemplate(key string) string {
 	return "{file:" + key + "}"
 }
+
+// GetByTemplate テンプレート形式の入力からxpathを取得する
+func (fs *FileSetting) GetByTemplate(template string) string {
+	for key := range fs.Files {
+		if t := fs.GetTemplate(key); t == template {
+			return fs.Files[key]
+		}
+	}
+
+	return ""
+}

--- a/setting/text.go
+++ b/setting/text.go
@@ -17,3 +17,14 @@ func NewTextSetting() TextSetting {
 func (fs *TextSetting) GetTemplate(key string) string {
 	return "{text:" + key + "}"
 }
+
+// GetByTemplate テンプレート形式の入力からtextを取得する
+func (fs *TextSetting) GetByTemplate(template string) string {
+	for key := range fs.Texts {
+		if t := fs.GetTemplate(key); t == template {
+			return fs.Texts[key]
+		}
+	}
+
+	return ""
+}

--- a/setting/text.go
+++ b/setting/text.go
@@ -1,5 +1,7 @@
 package setting
 
+import "strings"
+
 // TextSetting 変換を行うテキストの設定の構造体
 type TextSetting struct {
 	Texts map[string]string `yaml:"texts"`
@@ -14,17 +16,20 @@ func NewTextSetting() TextSetting {
 
 // getTemplate 変換を行う定義のテンプレートの値を取得
 // ファイルの場合は {text:VAR_NAME} の形式で入力されたものに対して変換を実行
-func (fs *TextSetting) getTemplate(key string) string {
+func (ts *TextSetting) getTemplate(key string) string {
 	return "{text:" + key + "}"
 }
 
-// GetByTemplate テンプレート形式の入力からtextを取得する
-func (fs *TextSetting) GetByTemplate(template string) string {
-	for key := range fs.Texts {
-		if t := fs.getTemplate(key); t == template {
-			return fs.Texts[key]
+// GetTemplates テンプレート形式が含まれた入力からfileを取得する
+func (ts *TextSetting) GetTemplates(s string) map[string]string {
+	templates := make(map[string]string)
+
+	for key := range ts.Texts {
+		template := ts.getTemplate(key)
+		if strings.Contains(s, template) {
+			templates[template] = ts.Texts[key]
 		}
 	}
 
-	return ""
+	return templates
 }

--- a/setting/text.go
+++ b/setting/text.go
@@ -12,16 +12,16 @@ func NewTextSetting() TextSetting {
 	}
 }
 
-// GetTemplate 変換を行う定義のテンプレートの値を取得
+// getTemplate 変換を行う定義のテンプレートの値を取得
 // ファイルの場合は {text:VAR_NAME} の形式で入力されたものに対して変換を実行
-func (fs *TextSetting) GetTemplate(key string) string {
+func (fs *TextSetting) getTemplate(key string) string {
 	return "{text:" + key + "}"
 }
 
 // GetByTemplate テンプレート形式の入力からtextを取得する
 func (fs *TextSetting) GetByTemplate(template string) string {
 	for key := range fs.Texts {
-		if t := fs.GetTemplate(key); t == template {
+		if t := fs.getTemplate(key); t == template {
 			return fs.Texts[key]
 		}
 	}

--- a/setting/xpath.go
+++ b/setting/xpath.go
@@ -15,7 +15,7 @@ func NewXpathSetting() XpathSetting {
 // GetByTemplate テンプレート形式の入力からxpathを取得する
 func (xs *XpathSetting) GetByTemplate(template string) string {
 	for key := range xs.Xpaths {
-		if t := xs.GetTemplate(key); t == template {
+		if t := xs.getTemplate(key); t == template {
 			return xs.Xpaths[key]
 		}
 	}
@@ -23,9 +23,9 @@ func (xs *XpathSetting) GetByTemplate(template string) string {
 	return ""
 }
 
-// GetTemplate 変換を行う定義のテンプレートの値を取得
+// getTemplate 変換を行う定義のテンプレートの値を取得
 // ファイルの場合は {xpath:VAR_NAME} の形式で入力されたものに対して変換を実行
-func (xs *XpathSetting) GetTemplate(key string) string {
+func (xs *XpathSetting) getTemplate(key string) string {
 	return "{xpath:" + key + "}"
 }
 

--- a/setting/xpath.go
+++ b/setting/xpath.go
@@ -12,6 +12,17 @@ func NewXpathSetting() XpathSetting {
 	}
 }
 
+// GetByTemplate テンプレート形式の入力からxpathを取得する
+func (xs *XpathSetting) GetByTemplate(template string) string {
+	for key := range xs.Xpaths {
+		if t := xs.GetTemplate(key); t == template {
+			return xs.Xpaths[key]
+		}
+	}
+
+	return ""
+}
+
 // GetTemplate 変換を行う定義のテンプレートの値を取得
 // ファイルの場合は {xpath:VAR_NAME} の形式で入力されたものに対して変換を実行
 func (xs *XpathSetting) GetTemplate(key string) string {

--- a/setting/xpath.go
+++ b/setting/xpath.go
@@ -1,5 +1,9 @@
 package setting
 
+import (
+	"strings"
+)
+
 // XpathSetting 変換を行うxpathの設定の構造体
 type XpathSetting struct {
 	Xpaths map[string]string `yaml:"xpaths"`
@@ -12,15 +16,18 @@ func NewXpathSetting() XpathSetting {
 	}
 }
 
-// GetByTemplate テンプレート形式の入力からxpathを取得する
-func (xs *XpathSetting) GetByTemplate(template string) string {
+// GetTemplates テンプレート形式が含まれた入力からfileを取得する
+func (xs *XpathSetting) GetTemplates(s string) map[string]string {
+	templates := make(map[string]string)
+
 	for key := range xs.Xpaths {
-		if t := xs.getTemplate(key); t == template {
-			return xs.Xpaths[key]
+		template := xs.getTemplate(key)
+		if strings.Contains(s, template) {
+			templates[template] = xs.Xpaths[key]
 		}
 	}
 
-	return ""
+	return templates
 }
 
 // getTemplate 変換を行う定義のテンプレートの値を取得


### PR DESCRIPTION
## 概要

`strings.Index(c.Target, key) != -1`等の部分一致で想定とは違ったケースにマッチ（例えば、TEST_MESSAGE_XPATHのテンプレートにTEST_MESSAGEキーがマッチ）して置換されなかった

## やったこと

- キーをテンプレート形式に変換してから比較するように変更
- 修正に伴ってリファクタリング
- xpath設定ファイルの値にはxpath=を付与して置換するように変更